### PR TITLE
Added "AM/PM" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Right now this lib supports the tokens below.
 |              | `mm`   | `01`, `02`, ... , `58`,`59`.        |
 |       Second | `s`    | `1`, `2`, ... , `58`,`59`.          |
 |              | `ss`   | `01`, `02`, ... , `58`,`59`.        |
+|       AM/PM  | `A`    | `AM`, `PM`.                         |
+|              | `a`    | `am`, `pm`.                         |
 |       Escape | `[*]`  | &nbsp;                              |
 
 ## License

--- a/src/format-date.ts
+++ b/src/format-date.ts
@@ -15,6 +15,8 @@ const FORMATTERS: Record<string, (date: Date) => string> = {
   'm':    date => '' + date.getMinutes(),
   'ss':   date => addZeroPads(2, '' + date.getSeconds()),
   's':    date => '' + date.getSeconds(),
+  'a':    date => '' + (date.getHours() >= 12 ? 'pm' : 'am'),
+  'A':    date => '' + (date.getHours() >= 12 ? 'PM' : 'AM'),
 };
 
 /**


### PR DESCRIPTION
I added new formatter tokens for "A" (AM/PM) and "a" (am/pm). I also updated the readme to reflect those changes.